### PR TITLE
Add initial tox configuration file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = clean,py310
+
+isolated_build = True
+
+[testenv]
+extras = tests
+commands = pytest src/wipplpy


### PR DESCRIPTION
This PR adds `tox.ini`, which is the configuration file that sets up different [tox](https://tox.wiki/) environments.  There's a bit hidden in the configuration, but to do tests on Python 3.9, 3.10, or 3.11, we can do:
```bash
tox -e py39
tox -e py310
tox -e py311
```