### PR TITLE
Add nox testing environment for building docs 📚

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,8 @@
+import nox
+
+
+@nox.session(python="3.12")
+def build_docs(session):
+    """Build documentation with Sphinx."""
+    session.install("sphinx")
+    session.run("sphinx-build", "-b", "html", "docs/source/", "docs/build/")


### PR DESCRIPTION
This PR adds a configuration file for [nox](https://nox.thea.codes/en/stable/), `noxfile.py`, which includes the `build_docs` environment for building documentation. 

Instructions:

 - Install `nox` with `pip install nox`
 - Navigate to the top-level directory of the repo
 - Run `nox -e build_docs`.

The index page out the output will be at `docs/build/html/index.html`.