### PR TITLE
Update to module path in generic_get_data.py

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -160,17 +160,17 @@ create an environment for running the code in.
       import os
       print('WiPPLPy source code directory:', os.getcwd())
 
-6. Exit out of python and nagigate to the :file:`site-packages` directory that 
+6. Exit out of python and navigate to the :file:`site-packages` directory that 
    was printed. It should end in :file:`site-packages`.
 
 7. Create a file called :file:`wipplpy.pth`. This file should contain the path 
-   to the :file:`WiPPLPy/source/` directory. For example, if the path to the 
-   :file:`WiPPLPy/source/` directory is :file:`/Users/username/repos/WiPPLPy/source/` 
+   to the :file:`WiPPLPy/src/` directory. For example, if the path to the 
+   :file:`WiPPLPy/src/` directory is :file:`/Users/username/repos/WiPPLPy/src/` 
    then the :file:`wipplpy.pth` file should contain the following:
 
    .. code-block:: bash
 
-      /Users/username/repos/WiPPLPy/source/
+      /Users/username/repos/WiPPLPy/src/
 
 8. Test that the installation was successful by running the following Python 
    code:

--- a/src/wipplpy/modules/generic_get_data.py
+++ b/src/wipplpy/modules/generic_get_data.py
@@ -4,7 +4,7 @@ import re
 import numpy as np
 from MDSplus.connection import Connection, MdsIpException
 from MDSplus.mdsExceptions import MDSplusException, SsSUCCESS
-from modules.shot_loader import get_remote_shot_tree
+from wipplpy.modules.shot_loader import get_remote_shot_tree 
 from scipy.io import loadmat, savemat
 
 


### PR DESCRIPTION
In changes to where this code exists, some previously used paths in module names were broken. Updated these paths so now imports from generic_get_data.py should work. Also updated html for installation instructions for a spelling error and paths towards end of guide that weren't consistent with current file names.