### PR TITLE
Switch the pytest runner to nox and update tested versions of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,22 +23,22 @@ jobs:
       matrix:
         include:
 
-        - name: Python 3.12 (Ubuntu)
+        - name: Tests, Python 3.12, Ubuntu
           os: ubuntu-latest
           python: '3.12'
           nox_session: tests-3.12
 
-        - name: Python 3.11 (macOS)
+        - name: Tests, Python 3.11, macOS
           os: macos-latest
           python: '3.11'
           nox_session: tests-3.11
 
-        - name: Python 3.10 (Windows)
+        - name: Tests, Python 3.10, Windows
           os: windows-latest
           python: '3.10'
           nox_session: tests-3.10
 
-        - name: Python 3.12 (Ubuntu)
+        - name: Documentation, Python 3.12, Ubuntu
           os: ubuntu-latest
           python: '3.12'
           nox_session: docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         include:
 
-        - name: Tests, Python 3.12, Ubuntu
+        - name: Tests, Python 3.9, Ubuntu
           os: ubuntu-latest
-          python: '3.12'
-          nox_session: tests-3.12
+          python: '3.9'
+          nox_session: tests-3.9
 
         - name: Tests, Python 3.11, macOS
           os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
 
-  initial-tests:
+  tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
@@ -23,21 +23,20 @@ jobs:
       matrix:
         include:
 
-        - name: Python 3.11 (Linux)
+        - name: Python 3.12 (Ubuntu)
           os: ubuntu-latest
-          python: '3.11'
-          toxenv: py311
-          toxargs: --develop
+          python: '3.12'
+          nox_session: tests-3.12
 
-        - name: Python 3.10 (MacOS)
+        - name: Python 3.11 (macOS)
           os: macos-latest
-          python: '3.10'
-          toxenv: py310
+          python: '3.11'
+          nox_session: tests-3.11
 
-        - name: Python 3.9 (Windows)
+        - name: Python 3.10 (Windows)
           os: windows-latest
-          python: 3.9
-          toxenv: py39
+          python: '3.10'
+          nox_session: tests-3.10
 
     steps:
 
@@ -53,13 +52,13 @@ jobs:
           cache: pip
 
       - name: Install Python dependencies
-        run: python -m pip install --progress-bar off --upgrade tox
+        run: python -m pip install --progress-bar off --upgrade nox uv
 
       - name: Run tests
-        run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+        run: nox -s ${{ matrix.nox_session }}
 
       - name: Upload coverage to codecov
-        if: ${{ contains(matrix.toxenv,'-cov') }}
+        if: ${{ contains(matrix.nox_session,'cov') }}
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           python: '3.10'
           nox_session: tests-3.10
 
+        - name: Tests, Python 3.10, macOS
+          os: macos-latest
+          python: '3.9'
+          nox_session: tests-3.9
+
         - name: Documentation, Python 3.12, Ubuntu
           os: ubuntu-latest
           python: '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           python: '3.10'
           nox_session: tests-3.10
 
+        - name: Python 3.12 (Ubuntu)
+          os: ubuntu-latest
+          python: '3.12'
+          nox_session: docs
+
     steps:
 
       - name: Checkout code

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,16 @@
 import nox
 
 
+PYTHON_VERSIONS=("3.10", "3.11", "3.12")
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def tests(session):
+    """Run tests with pytest."""
+    session.install(".")
+    session.run(pytest)
+
+
 @nox.session(python="3.12")
 def build_docs(session):
     """Build documentation with Sphinx."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def tests(session):
 
 
 @nox.session(python=maxpython)
-def build_docs(session):
+def docs(session):
     """Build documentation with Sphinx."""
     session.install("sphinx")
     session.run("sphinx-build", "-b", "html", "docs/source/", "docs/build/")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,17 +1,23 @@
 import nox
 
 
-PYTHON_VERSIONS=("3.10", "3.11", "3.12")
+supported_python_versions = ("3.10", "3.11", "3.12")
+maxpython = max(supported_python_versions)
+
+# Set the default backend to conda if available, because it is probably
+# needed to install MDSplus installation anyway. The next choice is uv
+# because it has excellent performance when resolving requirements.
+nox.options.default_venv_backend = "conda|uv|virtualenv"
 
 
-@nox.session(python=PYTHON_VERSIONS)
+@nox.session(python=supported_python_versions)
 def tests(session):
     """Run tests with pytest."""
     session.install(".")
     session.run(pytest)
 
 
-@nox.session(python="3.12")
+@nox.session(python=maxpython)
 def build_docs(session):
     """Build documentation with Sphinx."""
     session.install("sphinx")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,5 @@
 import nox
 
-
 supported_python_versions = ("3.9", "3.10", "3.11", "3.12")
 maxpython = max(supported_python_versions)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-supported_python_versions = ("3.10", "3.11", "3.12")
+supported_python_versions = ("3.9", "3.10", "3.11", "3.12")
 maxpython = max(supported_python_versions)
 
 # Set the default backend to conda if available, because it is probably

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = clean,py310
-
-isolated_build = True
-
-[testenv]
-extras = tests
-commands = pytest src/wipplpy


### PR DESCRIPTION
This PR makes the following changes:

 - 🧪 Added a Nox session for performing tests, and updated the GitHub workflow for CI to include these sessions.
 - ⬆️ Updated the versions of Python in `noxfile.py` and CI to be those released in the past 36 months (as per the convention recommended by [SPEC 0](https://scientific-python.org/specs/spec-0000/))
 - ✂️ Deleted `tox.ini`.
 - 🏷️ Renamed a Nox session from `build_docs` → `docs` to shorten the command, and for consistency with PlasmaPy.
 - 🏷️ Renamed CI workflows to be consistent with PlasmaPy

> [!IMPORTANT]
> Building docs now requires doing `nox -s docs`.