### PR TITLE
Update pre-commit hooks and perform package maintenance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
   rev: v4.6.0
   hooks:
   - id: check-ast
+    name: check abstract syntax tree
   - id: check-merge-conflict
     exclude: .*\.rst
   - id: check-case-conflict
@@ -31,12 +32,6 @@ repos:
   rev: v1.5.5
   hooks:
   - id: remove-crlf
-
-- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.13.0
-  hooks:
-  - id: pretty-format-ini
-    args: [--autofix]
 
 - repo: https://github.com/MarcoGorelli/absolufy-imports
   rev: v0.3.1
@@ -63,8 +58,9 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.4.8
   hooks:
-  - id: ruff
+  - id: ruff (see https://docs.astral.sh/ruff/rules)
     args: [--fix]
+  - id: ruff-format
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.13.2
@@ -77,15 +73,15 @@ repos:
     types:
     - python
 
-- repo: https://github.com/psf/black
-  rev: 24.4.2
-  hooks:
-  - id: black
-
 - repo: https://github.com/asottile/blacken-docs
   rev: 1.16.0
   hooks:
   - id: blacken-docs
+
+- repo: https://github.com/sphinx-contrib/sphinx-lint
+  rev: v0.9.1
+  hooks:
+  - id: sphinx-lint
 
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.8.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
     - tomli
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.7
+  rev: v0.4.8
   hooks:
   - id: ruff
     args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,8 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.4.8
   hooks:
-  - id: ruff (see https://docs.astral.sh/ruff/rules)
+  - id: ruff
+    name: ruff (see https://docs.astral.sh/ruff/rules)
     args: [--fix]
   - id: ruff-format
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-Look at this great README! What a wonderful first commit.
+# WiPPLPy
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # WiPPLPy
 
+Easily access data from plasma devices in the Wisconsin Plasma Physics Laboratory (WiPPL).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ tests = [
 [tool.codespell]
 skip = "*.png"
 ignore-words-list = """
-tru
-ned"""
+ned,
+tru"""
 
 [tool.ruff]
 target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ tests = [
 [tool.codespell]
 skip = "*.png"
 ignore-words-list = """
+tru
 ned"""
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,14 @@ description = "Python package for the Wisconsin Plasma Physics Laboratory"
 dynamic = [
   "version",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-  "numpy >= 1.22.0",
+  "numpy >= 1.24.0",
 ]
 [project.optional-dependencies]
 tests = [
-  "pytest >= 7.0.0",
-  "tox >= 4.3.1",
+  "pytest >= 8.0.0",
+  "nox >= 2024.4.15",
 ]
 
 [tool.codespell]
@@ -28,7 +28,7 @@ ned,
 tru"""
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 extend-select = [
   "A", # flake8-builtins
   "C4", # flake8-comprehensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "Python package for the Wisconsin Plasma Physics Laboratory"
 dynamic = [
   "version",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
   "numpy >= 1.24.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ ned,
 tru"""
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py39"
 extend-select = [
   "A", # flake8-builtins
   "C4", # flake8-comprehensions


### PR DESCRIPTION

 - Changed from black to ruff-format as code autoformatter
 - Removed pre-commit hook for `.ini` files (will no longer necessary after #29)
 - Added sphinx-lint, which looks for common reStructuredText and Sphinx mistakes
 - Updated `README.md` to include the package description for the GitHub repo
 - Updated versions of Python and NumPy, to be consistent with [SPEC 0](https://scientific-python.org/specs/spec-0000/)
 - Updated optional requirements to be a bit more recent (since these are not needed for package installation, we can be a bit more strict)
 - Updated the codespell ignore words list (in `pyproject.toml`)
