### PR TITLE
Add verbose option to `session.run`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,6 +15,7 @@ def install_environment(session, environment_path="mamba_environment.yml"):
             session.venv_backend,
             "env",
             "update",
+            "--verbose",
             "--prefix",
             session.virtualenv.location,
             "--file",


### PR DESCRIPTION
Make the mamba installs verbose when running the Github CI.